### PR TITLE
Fix strain table formatting, add dark theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1
+
+- Fixed formatting of the strain table
+- Fixed dark theme formatting of strain lozenges
+
 ## 1.1 D&D 3.3
 
 - Increased minimum version to 3.3

--- a/styles/_dnd5e-theme-dark.scss
+++ b/styles/_dnd5e-theme-dark.scss
@@ -1,0 +1,27 @@
+.dnd5e-theme-dark {
+    .dnd5e2.sheet.actor {
+        .tab.strain {
+            .lozenge {
+                &::before {
+                    content: '';
+                    position: absolute;
+                    width: 68px;
+                    height: 30px;
+                    background: transparent url(../../../systems/dnd5e/ui/lozenge.svg)
+                      no-repeat top center / contain;
+                    background-size: cover;
+                    z-index: 0;
+                }
+                input {
+                    color: var(--color-text-light-0);
+                }
+                .value.max {
+                    color: var(--color-text-light-3);
+                }
+                .label {
+                    color: var(--dnd5e-color-gold);
+                }
+            }
+        }
+    }
+}

--- a/styles/_dnd5e2.scss
+++ b/styles/_dnd5e2.scss
@@ -81,6 +81,9 @@ $font-family_2: var(--dnd5e-font-roboto-condensed);
       padding: 0.25rem;
     }
     .items-section {
+      li.item {
+        display: flex;
+      }
       div {
         width: 100%;
         display: flex;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,3 +1,4 @@
+@import './dnd5e-theme-dark';
 @import './dnd5e';
 @import './dnd5e2';
 @import './tidy5e';


### PR DESCRIPTION
## What's the bug?

The strain tab formatting has broken, and isn't formatting as a table properly

![image](https://github.com/user-attachments/assets/c34426ba-2c5c-4dd4-95c6-d7c35234b6b8)

## Why is it happening?

Version 3.3.0 of the dnd5e system tweaked the CSS for sheet inventory, moving `display: flex;` from `.dnd5e2 .items-section .item`, onto a child element:
https://github.com/foundryvtt/dnd5e/commit/a52a0f456575ed10a019ea563a8d5e918bc8bacb#diff-afe30fe73f6b5d6ed04d87de56ab2880d0d9ecd6e49fcb6a75cf24b94da339da

## How is it fixed?

Re-add `diplay: flex` onto  `li.item` in the strain tab

I've also added some bespoke formatting for dark theme to make the lozenges and the numbers on them show up better

## Screenshots

![image](https://github.com/user-attachments/assets/3a916a14-caa5-4459-9dc5-1158e162458b)

## Notes

The changes are only partially tested; I haven't tried compiling the scss
