### PR TITLE
[Feature] Automate strain recovery on long rest

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -83,7 +83,8 @@
           "7": "When a supernatural effect causes you to regain hit points, you regain only half the amount you normally would",
           "8": "No effect"
         }
-      }
+      },
+      "NoStrainRecoveryWarn": "{name} has no {strainType} to recover!"
     }
   },
   "DND5E": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
       "ManifestingHeader": "Power Manifesting",
       "Effects": "Power Effects",
       "ManifestTime": "Manifestation Time",
+      "ManifestTestDC": "DC {manifestDC} Manifestation Test",
       "ManifestDie": "Manifestation Die",
       "ManifestDieFlavor": "Manifestation Die (Order {order})",
       "RollManifestDieLabel": "Roll Manifest Die",

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -10,6 +10,9 @@ export const moduleID = "talent-psionics";
 export const typePower = moduleID + ".power";
 export const modulePath = (path) => "modules/talent-psionics/" + path;
 export const STRAIN_FLAG = "strain";
+export const STRAIN_BODY_FLAG = "body";
+export const STRAIN_MIND_FLAG = "mind";
+export const STRAIN_SOUL_FLAG = "soul";
 
 export function calculateMaxStrain(actor) {
   return actor.classes?.talent?.system?.levels + 4;

--- a/talent-psionics.mjs
+++ b/talent-psionics.mjs
@@ -170,7 +170,8 @@ Hooks.on("renderActorSheet5e", (sheet, html, context) => {
             itemContext.range = {
               distance: true,
               value: power.system.range.value,
-              unit: game.i18n.localize(`DND5E.Dist${units.capitalize()}Abbr`)
+              unit: game.i18n.localize(`DND5E.Dist${units.capitalize()}Abbr`),
+              parts: dnd5e.utils.formatLength(power.system.range.value, units, { parts: true })
             };
           } else itemContext.range = {distance: false};
         }

--- a/talent-psionics.mjs
+++ b/talent-psionics.mjs
@@ -1,6 +1,8 @@
 import PowerData from "./module/powerData.mjs";
 import PowerSheet from "./module/powerSheet.mjs";
 import TP_CONFIG from "./module/config.mjs";
+import ManifestDie from "./module/manifestDie.mjs";
+
 import {
   ACTOR_SHEETS,
   STRAIN_FLAG,
@@ -320,3 +322,7 @@ function saveActorIdOnStrainTab(actor) {
     lastUpdatedStrainActorId = null;
   }
 }
+
+Hooks.on("renderChatMessage", (message, html) => {
+  ManifestDie.onRenderChatMessage(message, html);
+})

--- a/talent-psionics.mjs
+++ b/talent-psionics.mjs
@@ -346,17 +346,6 @@ Hooks.on("renderShortRestDialog", async (dialog, element) => {
   async function recoverStrain(type) {
     let size = html.find('[name="denom"]').val();
 
-    // Otherwise, locate a class (if any) which has an available hit die of the requested denomination
-    let cls = dialog.actor.system.attributes.hd.classes.find(i => {
-      return (i.system.hd.denomination === size) && i.system.hd.value;
-    });
-
-    // If no class is available, display an error notification
-    if(!cls) {
-      ui.notifications.error(game.i18n.format("DND5E.HitDiceWarn", {name: dialog.actor.name, formula: size}));
-      return false;
-    }
-
     // check that there is strain to recover
     const strain = dialog.actor.getFlag(moduleID, STRAIN_FLAG);
     if(strain[type] === 0) {
@@ -364,12 +353,9 @@ Hooks.on("renderShortRestDialog", async (dialog, element) => {
       ui.notifications.error(game.i18n.format("TalentPsionics.Strain.NoStrainRecoveryWarn", {name: dialog.actor.name, strainType: strainLabel}));
       return false;
     }
-    
-    // Consume HD
-    const updates = { actor: {}, class: {} };
-    updates.class["system.hd.spent"] = cls.system.hd.spent + 1
 
-    await cls.update(updates.class);
+    // Consumes hitdice without recovering hit points
+    dialog.actor.rollHitDie({ denomination: size, modifyHitPoints: false}, {}, {create: false});
 
     // Recover Strain
     strain[type] -= 1;

--- a/templates/manifest-check-dc.hbs
+++ b/templates/manifest-check-dc.hbs
@@ -1,0 +1,6 @@
+<div class="dice-formula" style="margin-top: 4px; padding: 8px;">
+    <i class="fas fa-shield-heart" style="margin-right: 2px" inert></i>
+    <span style="font-family: var(--dnd5e-font-roboto); font-weight: bold; text-transform: uppercase">
+        {{ localize "TalentPsionics.Power.ManifestTestDC" manifestDC=DC }}
+    </span>
+</div>

--- a/templates/short-rest-strain-recovery.hbs
+++ b/templates/short-rest-strain-recovery.hbs
@@ -1,0 +1,8 @@
+<div class="form-group">
+    <label>Recover Strain</label>  
+    <div class="form-fields">
+    <button type="button" id="recover-strain-body">Body</button>
+    <button type="button" id="recover-strain-mind">Mind</button>
+    <button type="button" id="recover-strain-soul">Soul</button>
+    </div>
+</div>


### PR DESCRIPTION
## What's the change?
Strain is automatically recovered on long rest.

## How is it done?
Uses the dnd5e.preRestCompleted hook to reset strain to 0. 
If a change to strain has been made, it also hooks onto preCreateChatMessage to prettify the update strings.

## Screenshots
![image](https://github.com/user-attachments/assets/4127bed1-8b15-4769-9b58-a085a4e28911)

